### PR TITLE
ui-bug: fix wrong bookmark relocation message

### DIFF
--- a/src/popup/components/PBPopupItem.vue
+++ b/src/popup/components/PBPopupItem.vue
@@ -75,7 +75,20 @@ export default {
     const pctStr = computed(() => (settingsPUUI.compact ? Math.floor(p.work.pct * 100) : (p.work.pct * 100).toFixed(2)) + '%')
 
     const btnTitle = computed(() => {
-      const remarks = (p.work.v !== settingsPU.view) ? `\n(This bookmark will be relocated to [${CUSTOM_VIEW_STR[p.work.v] || 'No status'}])` : ''
+      let remarks = '' 
+      
+      /**
+       * bookmark relocation message is NOT shown only if
+       *  - under 'All(-1)' view
+       *  - under 'No status(-2)' view AND latest work.v is null
+       *  - under 'Unread(0)/Reading(1)/Complete(2)' view AND latest work.v === settingsPU.view
+       */
+      if (settingsPU.view !== -1 && !(settingsPU.view === -2 && p.work.v === null)) {
+        if (p.work.v !== settingsPU.view) {
+          remarks = `\n(This bookmark will be relocated to [${CUSTOM_VIEW_STR[p.work.v] || 'No status'}])`
+        }
+      }
+
       const pctStrFull = (p.work.pct * 100).toFixed(2) + '%'
       
       if (p.work.os) return `Visit One-shot (${pctStrFull})${remarks}`


### PR DESCRIPTION
Issue: https://github.com/catcoder13/ao3-progress-bookmark/issues/1

Fix wrong relocation message.
Correction:

1. All view

<img width="314" alt="image" src="https://github.com/catcoder13/ao3-progress-bookmark/assets/131194102/eb41355e-e746-4ea4-8122-04ab833cfcb4">


2. No status view

<img width="313" alt="image" src="https://github.com/catcoder13/ao3-progress-bookmark/assets/131194102/205dd16d-bc14-4816-862d-80c4709d6ed9">
